### PR TITLE
b64_data : use Base64.strict_encode64

### DIFF
--- a/lib/dragonfly/content.rb
+++ b/lib/dragonfly/content.rb
@@ -184,7 +184,7 @@ module Dragonfly
     #   "data:image/jpeg;base64,IGSsdhfsoi..."
     # @return [String] A data url representation of the data
     def b64_data
-      "data:#{mime_type};base64,#{Base64.encode64(data)}"
+      "data:#{mime_type};base64,#{Base64.strict_encode64(data)}"
     end
 
     def close


### PR DESCRIPTION
Base64.encode64 adds newlines every 60th characters and it causes troubles with some browsers (at least Chrome).
